### PR TITLE
Feat db prefix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 vendor
+.idea

--- a/src/Commands/MigrateForumCommand.php
+++ b/src/Commands/MigrateForumCommand.php
@@ -1,46 +1,39 @@
 <?php
-
 namespace Socieboy\Forum\Commands;
 
 use Illuminate\Console\Command;
 
 class MigrateForumCommand extends Command
 {
+    /**
+     * The console command name.
+     *
+     * @var string
+     */
+    protected $name = 'forum:migrate';
 
-	/**
-	 * The console command name.
-	 *
-	 * @var string
-	 */
-	protected $name = 'forum:migrate';
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Create a forum migrations';
 
-	/**
-	 * The console command description.
-	 *
-	 * @var string
-	 */
-	protected $description = 'Create a forum migrations';
-
-	/**
-	 * Execute the console command.
-	 * @return mixed
-	 */
-	public function fire()
-	{
-
+    /**
+     * Execute the console command.
+     * @return mixed
+     */
+    public function fire()
+    {
         $this->createMigration('conversations');
-
         $this->createMigration('replies');
 
         sleep(1);
 
         $this->createMigration('likes');
-
-
         $this->info('Migrations created successfully!');
-
         $this->laravel['composer']->dumpAutoloads();
-	}
+    }
 
     /**
      * Create a base migration file for the reminders.
@@ -50,12 +43,9 @@ class MigrateForumCommand extends Command
      */
     protected function createMigration($table)
     {
-        $name = 'create_'.$table.'_table';
-
-        $path = $this->laravel['path.database'].'/migrations';
-
+        $name = 'create_' . $table . '_table';
+        $path = $this->laravel['path.database'] . '/migrations';
         $migration = $this->laravel['migration.creator']->create($name, $path);
-
         file_put_contents($migration, $this->getMigrationStub($table));
     }
 
@@ -68,10 +58,10 @@ class MigrateForumCommand extends Command
      */
     protected function getMigrationStub($stub)
     {
-        if(file_exists(__DIR__.'/../Stubs/'.$stub.'.stub'))
-        {
-            return  file_get_contents( __DIR__.'/../Stubs/'.$stub.'.stub');
+        if (file_exists(__DIR__ . '/../Stubs/' . $stub . '.stub')) {
+            return file_get_contents(__DIR__ . '/../Stubs/' . $stub . '.stub');
         }
+
         throw new \Exception('We could not create the migration!');
     }
 

--- a/src/Config/forum.php
+++ b/src/Config/forum.php
@@ -1,19 +1,15 @@
 <?php
 
 return [
-
     /*
      * Define the path to your master view on your "resources/view" folder.
      */
-
-    'template'  => 'app',
-
+    'template' => 'app',
 
     /*
      * Define @yield( $content ) area where the forum views will be displayed on your app.
      */
-
-    'content'   => 'content',
+    'content' => 'content',
 
     /*
      * Define topics for the forum.
@@ -22,23 +18,32 @@ return [
      * The icon can be anyone of your prefer css framework like glyphicon or Font Awesome
      * Also you can and the key color, with the value of the representative color of the topic.
      */
-
     'topics' => [
-        'general' => ['name' => 'General', 'icon' => 'fa fa-tags', 'color' => 'rgb(78, 137, 218)']
+        'general' => [
+            'name' => 'General',
+            'icon' => 'fa fa-tags',
+            'color' => 'rgb(78, 137, 218)'
+        ]
     ],
 
+    /**
+     * Database configurations
+     */
+    'database' => [
+        /**
+         * Prefix for your tables
+         */
+        'prefix' => 'forum'
+    ],
 
     /**
      * User settings
      */
-
     'user' => [
-
         /**
          * Path to your user model.
          */
-
-        'model'         => \App\User::class,
+        'model' => \App\User::class,
 
         /**
          * Define the field on your table user that the forum will use to display the identify user.
@@ -52,57 +57,46 @@ return [
          *
          *  etc...
          */
-
-        'username'    => 'name',
+        'username' => 'name',
 
         /*
          * If you don't want to use gravatar
          * Place this key to true to use your own avatars.
          */
-
-        'avatar'        => false,
+        'avatar' => false,
 
         /**
          * Need avatars on your forum.
          */
-
-        'user-avatar'  => 'avatar',
+        'user-avatar' => 'avatar',
 
         /**
          * By default the forum uses gravatar.
          *
          * Set this to false to use your own avatars on the users table
          */
-
         'gravatar' => true,
-
-
 
         /**
          * Require links to user profile
          */
-
         'profile' => false,
 
         /**
          * Route name to user profile.
          * Has to accept one parameter > user ID.
          */
-
         'profile-route' => 'forum.user.profile',
-
     ],
 
     /**
      * User authentication
      */
     'auth' => [
-
         /**
          * Redirect to the login form.
          */
         'login-url' => 'auth/login'
-
     ],
 
     /**
@@ -110,33 +104,25 @@ return [
      * By default we use icons from bootstrap
      */
     'icons' => [
-        'like'              => 'glyphicon glyphicon-thumbs-up',
-        'correct-answer'    => 'glyphicon glyphicon-ok',
+        'like' => 'glyphicon glyphicon-thumbs-up',
+        'correct-answer' => 'glyphicon glyphicon-ok',
     ],
 
     /**
      * Send an email to the conversation owner each time someone left a reply
      */
-
     'emails' => [
-
         'fire' => false,
-
         /**
          * Set the email from
          */
         'from' => '',
-
         'from-name' => 'Admin',
-
         'subject' => 'Forum'
-
     ],
 
     /**
      * For broadcasting events you must set pusher keys.
      */
     'broadcasting' => false,
-
-
 ];

--- a/src/Controllers/ConversationController.php
+++ b/src/Controllers/ConversationController.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Socieboy\Forum\Controllers;
 
 use App\Http\Controllers\Controller;
@@ -10,7 +9,6 @@ use Socieboy\Forum\Requests\ConversationRequest;
 
 class ConversationController extends Controller
 {
-
     /**
      * @var ConversationRepo
      */
@@ -22,21 +20,18 @@ class ConversationController extends Controller
     function __construct(ConversationRepo $conversationRepo)
     {
         $this->middleware('auth', ['only' => ['store']]);
-
         $this->conversationRepo = $conversationRepo;
-
     }
 
     /**
      * Display a conversation and replies
      *
-     * @param $slug
+     * @param string $slug
      * @return \Illuminate\View\View
      */
     public function show($slug)
     {
         $conversation = $this->conversationRepo->findBySlug($slug);
-
         $replies = $conversation->replies()->orderBy('created_at', 'DESC')->paginate(4);
 
         return view('Forum::Conversations.show', compact('conversation', 'replies'));
@@ -50,10 +45,8 @@ class ConversationController extends Controller
      */
     public function store(ConversationRequest $request)
     {
-
         $this->dispatchFrom('Socieboy\Forum\Jobs\Conversations\StartConversation', $request);
 
         return redirect()->route('forum');
     }
-
 }

--- a/src/Controllers/ForumController.php
+++ b/src/Controllers/ForumController.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Socieboy\Forum\Controllers;
 
 use \App\Http\Controllers\Controller;
@@ -8,7 +7,6 @@ use Socieboy\Forum\Entities\Conversations\ConversationRepo;
 
 class ForumController extends Controller
 {
-
     /**
      * @var ConversationRepo
      */
@@ -39,7 +37,7 @@ class ForumController extends Controller
      * Display the main page of the forum.
      * All conversations are listed.
      *
-     * @param $topic_id
+     * @param string $topic_id
      * @return \Illuminate\View\View
      */
     public function topic($topic_id)
@@ -51,8 +49,9 @@ class ForumController extends Controller
 
 
     /**
-     * @param Request $request
+     * Search
      *
+     * @param Request $request
      * @return \Illuminate\View\View
      */
     public function search(Request $request)
@@ -61,7 +60,4 @@ class ForumController extends Controller
 
         return view('Forum::index', compact('conversations'));
     }
-
-
-
-} 
+}

--- a/src/Controllers/LikesController.php
+++ b/src/Controllers/LikesController.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Socieboy\Forum\Controllers;
 
 use Socieboy\Forum\Entities\Likes\LikeManager;
@@ -9,7 +8,6 @@ use Socieboy\Forum\Requests\LikeRequest;
 
 class LikesController extends Controller
 {
-
     /**
      * @var LikeRepo
      */
@@ -21,7 +19,6 @@ class LikesController extends Controller
     function __construct(LikeRepo $likeRepo)
     {
         $this->middleware('auth');
-
         $this->likeRepo = $likeRepo;
     }
 
@@ -29,7 +26,7 @@ class LikesController extends Controller
      * User hit the like button.
      *
      * @param LikeRequest $request
-     * @param $slug
+     * @param string $slug
      * @return \Illuminate\Http\RedirectResponse
      */
     public function like(LikeRequest $request, $slug)
@@ -41,17 +38,14 @@ class LikesController extends Controller
 
     /**
      * @param LikeRequest $request
-     * @param $slug
+     * @param string $slug
      *
      * @return \Illuminate\Http\RedirectResponse
      */
     public function unlike(LikeRequest $request, $slug)
     {
-
         $this->dispatchFrom('Socieboy\Forum\Jobs\UnLikeReply', $request);
 
         return redirect()->route('forum.conversation.show', $slug);
     }
-
-
-} 
+}

--- a/src/Controllers/ProfileController.php
+++ b/src/Controllers/ProfileController.php
@@ -1,11 +1,10 @@
 <?php
-
 namespace Socieboy\Forum\Controllers;
 
 use App\Http\Controllers\Controller;
 
-class ProfileController extends Controller{
-
+class ProfileController extends Controller
+{
     /**
      * Initialize profile controller.
      */
@@ -17,16 +16,14 @@ class ProfileController extends Controller{
     /**
      * Display forum profile user.
      *
-     * @param $id
+     * @param int $id
      * @return \Illuminate\View\View
      */
     public function show($id)
     {
         $userModel = config('forum.user.model');
-
         $user = $userModel::find($id);
 
         return view('Forum::User.profile', compact('user'));
     }
-
-} 
+}

--- a/src/Controllers/RepliesController.php
+++ b/src/Controllers/RepliesController.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Socieboy\Forum\Controllers;
 
 use App\Http\Controllers\Controller;
@@ -10,10 +9,6 @@ use Socieboy\Forum\Requests\CreateReplyRequest;
 
 class RepliesController extends Controller
 {
-
-    protected $replyRepo;
-
-
     /**
      * Implements the reply
      */
@@ -26,7 +21,7 @@ class RepliesController extends Controller
      * Store a new conversation.
      *
      * @param CreateReplyRequest $request
-     * @param $slug
+     * @param string $slug
      *
      * @return \Illuminate\Http\RedirectResponse
      */
@@ -50,5 +45,4 @@ class RepliesController extends Controller
 
         return redirect()->back();
     }
-
 }

--- a/src/Entities/BaseModel.php
+++ b/src/Entities/BaseModel.php
@@ -1,0 +1,16 @@
+<?php
+namespace Socieboy\Forum\Entities;
+
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Facades\Config;
+
+class BaseModel extends Model
+{
+    /**
+     * Set table prefix if any
+     */
+    public function __construct()
+    {
+        $this->table = (Config::get('forum.database.prefix') ? Config::get('forum.database.prefix') . '_' : '') . $this->table;
+    }
+}

--- a/src/Entities/Conversations/Conversation.php
+++ b/src/Entities/Conversations/Conversation.php
@@ -1,12 +1,10 @@
 <?php
-
 namespace Socieboy\Forum\Entities\Conversations;
 
 use Illuminate\Database\Eloquent\Model;
 
 class Conversation extends Model
 {
-
     /**
      * @var string
      */
@@ -15,7 +13,13 @@ class Conversation extends Model
     /**
      * @var array
      */
-    protected $fillable = ['user_id', 'title', 'message', 'topic_id', 'slug'];
+    protected $fillable = [
+        'user_id',
+        'title',
+        'message',
+        'topic_id',
+        'slug'
+    ];
 
     /**
      * Return the user owner of this conversation.
@@ -37,38 +41,43 @@ class Conversation extends Model
         return $this->hasMany('Socieboy\Forum\Entities\Replies\Reply')->latest();
     }
 
+    /**
+     * Get owner name attribute
+     * @return string
+     */
     public function getOwnerNameAttribute()
     {
         return $this->user->{config('forum.user.username')};
     }
+
     /**
      * Return the topic name.
      *
-     * @return mixed
+     * @return string
      */
     public function getTopicAttribute()
     {
-        return config('forum.topics.'.$this->topic_id)['name'];
+        return config('forum.topics.' . $this->topic_id)['name'];
     }
 
     /**
      * Return the topic icon.
      *
-     * @return mixed
+     * @return string
      */
     public function getTopicIconAttribute()
     {
-        return config('forum.topics.'.$this->topic_id)['icon'];
+        return config('forum.topics.' . $this->topic_id)['icon'];
     }
 
     /**
      * Return the topic color.
      *
-     * @return mixed
+     * @return string
      */
     public function getTopicColorAttribute()
     {
-        return config('forum.topics.'.$this->topic_id)['color'];
+        return config('forum.topics.' . $this->topic_id)['color'];
     }
 
     /**
@@ -78,24 +87,25 @@ class Conversation extends Model
      */
     public function hasCorrectAnswer()
     {
-        foreach($this->replies as $reply)
-        {
-            if($reply->isCorrect()) return true;
+        foreach ($this->replies as $reply) {
+            if ($reply->isCorrect()) {
+                return true;
+            }
         }
 
         return false;
     }
 
-
     /**
-     *
+     * Return correct answer
      * @return mixed
      */
     public function correctAnswer()
     {
-        foreach($this->replies as $reply)
-        {
-            if($reply->isCorrect()) return $reply;
+        foreach ($this->replies as $reply) {
+            if ($reply->isCorrect()) {
+                return $reply;
+            }
         }
     }
 }

--- a/src/Entities/Conversations/Conversation.php
+++ b/src/Entities/Conversations/Conversation.php
@@ -1,9 +1,9 @@
 <?php
 namespace Socieboy\Forum\Entities\Conversations;
 
-use Illuminate\Database\Eloquent\Model;
+use Socieboy\Forum\Entities\BaseModel;
 
-class Conversation extends Model
+class Conversation extends BaseModel
 {
     /**
      * @var string

--- a/src/Entities/Conversations/ConversationRepo.php
+++ b/src/Entities/Conversations/ConversationRepo.php
@@ -1,12 +1,10 @@
 <?php
-
 namespace Socieboy\Forum\Entities\Conversations;
 
 use Socieboy\Forum\Entities\Libs\BaseRepo;
 
 class ConversationRepo extends BaseRepo
 {
-
     /**
      * @return Conversation
      */
@@ -18,7 +16,7 @@ class ConversationRepo extends BaseRepo
     /**
      * Return all conversations of the topic given
      *
-     * @param $topic_id
+     * @param string $topic_id
      * @return mixed
      */
     public function topic($topic_id)
@@ -26,17 +24,16 @@ class ConversationRepo extends BaseRepo
         return $this->model->where('topic_id', $topic_id)->latest()->paginate(10);
     }
 
-
     /**
      * Search all conversations with the title like...
      *
-     * @param $data
+     * @param array $data
      * @return mixed
      */
     public function search($data)
     {
         $title = $data['title'];
 
-        return $this->model->where('title', 'LIKE', '%'.$title.'%')->latest()->paginate(10);
+        return $this->model->where('title', 'LIKE', '%' . $title . '%')->latest()->paginate(10);
     }
 }

--- a/src/Entities/Libs/BaseRepo.php
+++ b/src/Entities/Libs/BaseRepo.php
@@ -1,46 +1,45 @@
 <?php
-
 namespace Socieboy\Forum\Entities\Libs;
 
 abstract class BaseRepo
 {
+    protected $model;
 
-	protected $model;
-
-	public function __construct()
-	{
-
-		$this->model = $this->model();
-	}
-
-	abstract public function model();
-	
-	public function find($id, array $columns = array('*'))
-	{
-		return $this->model->find($id, $columns);
-	}
-
-	public function findOrFail($id, array $columns = array('*'))
-	{
-		return $this->model->findOrFail($id, $columns);
-	}
-
-	public function lists($column, $key = null)
-	{
-		return $this->model->lists($column, $key);
-	}
-
-	public function all($columns = array('*'))
-	{
-		return $this->model->all($columns);
-	}
-
-    public function where($column, $operator = null, $value = null){
-        return$this->model->where($column, $operator, $value);
+    public function __construct()
+    {
+        $this->model = $this->model();
     }
 
-    public function whereIn($colum, Array $array){
-        return$this->model->whereIn($colum, $array);
+    abstract public function model();
+
+    public function find($id, array $columns = array('*'))
+    {
+        return $this->model->find($id, $columns);
+    }
+
+    public function findOrFail($id, array $columns = array('*'))
+    {
+        return $this->model->findOrFail($id, $columns);
+    }
+
+    public function lists($column, $key = null)
+    {
+        return $this->model->lists($column, $key);
+    }
+
+    public function all($columns = array('*'))
+    {
+        return $this->model->all($columns);
+    }
+
+    public function where($column, $operator = null, $value = null)
+    {
+        return $this->model->where($column, $operator, $value);
+    }
+
+    public function whereIn($colum, Array $array)
+    {
+        return $this->model->whereIn($colum, $array);
     }
 
     public function paginate($number = 10)
@@ -58,12 +57,14 @@ abstract class BaseRepo
         return $this->model->groupBy($colum);
     }
 
-    public function latest(){
-        return$this->model->latest();
+    public function latest()
+    {
+        return $this->model->latest();
     }
 
-    public function take($num){
-        return$this->model->take($num);
+    public function take($num)
+    {
+        return $this->model->take($num);
     }
 
     public function onlyTrashed()
@@ -85,5 +86,4 @@ abstract class BaseRepo
     {
         return $this->model->where('slug', $slug)->get()->first();
     }
-
 }

--- a/src/Entities/Likes/Like.php
+++ b/src/Entities/Likes/Like.php
@@ -1,12 +1,10 @@
 <?php
-
 namespace Socieboy\Forum\Entities\Likes;
 
 use Illuminate\Database\Eloquent\Model;
 
 class Like extends Model
 {
-
     /**
      * @var string
      */
@@ -32,5 +30,4 @@ class Like extends Model
     {
         return $this->belongsTo(config('forum.user.model'));
     }
-
-} 
+}

--- a/src/Entities/Likes/Like.php
+++ b/src/Entities/Likes/Like.php
@@ -1,9 +1,9 @@
 <?php
 namespace Socieboy\Forum\Entities\Likes;
 
-use Illuminate\Database\Eloquent\Model;
+use Socieboy\Forum\Entities\BaseModel;
 
-class Like extends Model
+class Like extends BaseModel
 {
     /**
      * @var string

--- a/src/Entities/Likes/LikeRepo.php
+++ b/src/Entities/Likes/LikeRepo.php
@@ -1,12 +1,10 @@
 <?php
-
 namespace Socieboy\Forum\Entities\Likes;
 
 use Socieboy\Forum\Entities\Libs\BaseRepo;
 
 class LikeRepo extends BaseRepo
 {
-
     /**
      * @return Like
      */
@@ -14,6 +12,4 @@ class LikeRepo extends BaseRepo
     {
         return new Like;
     }
-
-
-} 
+}

--- a/src/Entities/Replies/Reply.php
+++ b/src/Entities/Replies/Reply.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Socieboy\Forum\Entities\Replies;
 
 use Illuminate\Database\Eloquent\Model;
@@ -7,7 +6,6 @@ use Illuminate\Support\Facades\Auth;
 
 class Reply extends Model
 {
-
     /**
      * @var string
      */
@@ -16,7 +14,11 @@ class Reply extends Model
     /**
      * @var array
      */
-    protected $fillable = ['user_id', 'conversation_id', 'message'];
+    protected $fillable = [
+        'user_id',
+        'conversation_id',
+        'message'
+    ];
 
     /**
      * Return the conversation parent of this reply.
@@ -53,22 +55,21 @@ class Reply extends Model
      *
      * @return bool
      */
-
     public function userLiked()
     {
-        foreach($this->likes as $like)
-        {
-            if($like->user->id == Auth::User()->id)
-            {
+        foreach ($this->likes as $like) {
+            if ($like->user->id == Auth::User()->id) {
                 return true;
             }
         }
         return false;
     }
 
+    /**
+     * @return bool
+     */
     public function isCorrect()
     {
         return $this->correct_answer == 1;
     }
-
 }

--- a/src/Entities/Replies/Reply.php
+++ b/src/Entities/Replies/Reply.php
@@ -1,10 +1,10 @@
 <?php
 namespace Socieboy\Forum\Entities\Replies;
 
-use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Auth;
+use Socieboy\Forum\Entities\BaseModel;
 
-class Reply extends Model
+class Reply extends BaseModel
 {
     /**
      * @var string

--- a/src/Entities/Replies/ReplyRepo.php
+++ b/src/Entities/Replies/ReplyRepo.php
@@ -1,12 +1,10 @@
 <?php
-
 namespace Socieboy\Forum\Entities\Replies;
 
 use Socieboy\Forum\Entities\Libs\BaseRepo;
 
 class ReplyRepo extends BaseRepo
 {
-
     /**
      * @return Reply
      */
@@ -14,5 +12,4 @@ class ReplyRepo extends BaseRepo
     {
         return new Reply;
     }
-
-} 
+}

--- a/src/Events/NewReply.php
+++ b/src/Events/NewReply.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Socieboy\Forum\Events;
 
 use App\Events\Event;
@@ -11,7 +10,11 @@ class NewReply extends Event implements ShouldBroadcast
 {
     use SerializesModels;
 
+    /**
+     * @var Reply
+     */
     public $reply;
+
     /**
      * Create a new event instance.
      *
@@ -29,7 +32,7 @@ class NewReply extends Event implements ShouldBroadcast
      */
     public function broadcastOn()
     {
-        return ['socieboy-forum-channel-'.$this->reply->conversation->user->id];
+        return ['socieboy-forum-channel-' . $this->reply->conversation->user->id];
     }
 
     /**
@@ -40,8 +43,8 @@ class NewReply extends Event implements ShouldBroadcast
     public function broadcastWith()
     {
         return [
-                'user' => $this->reply->user->{config('forum.user.username')},
-                'link' => route('forum.conversation.show', $this->reply->conversation->slug)
+            'user' => $this->reply->user->{config('forum.user.username')},
+            'link' => route('forum.conversation.show', $this->reply->conversation->slug)
         ];
     }
 }

--- a/src/Jobs/CheckCorrectAnswer.php
+++ b/src/Jobs/CheckCorrectAnswer.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Socieboy\Forum\Jobs;
 
 use App\Jobs\Job;
@@ -12,12 +11,12 @@ class CheckCorrectAnswer extends Job implements SelfHandling
     use SerializesModels;
 
     /**
-     * @var
+     * @var int
      */
     protected $reply_id;
 
     /**
-     * @param $reply_id
+     * @param int $reply_id
      */
     function __construct($reply_id)
     {
@@ -30,11 +29,7 @@ class CheckCorrectAnswer extends Job implements SelfHandling
     public function handle(ReplyRepo $replyRepo)
     {
         $reply = $replyRepo->findOrFail($this->reply_id);
-
-        $reply->correct_answer = ! $reply->correct_answer;
-
+        $reply->correct_answer = !$reply->correct_answer;
         $reply->save();
     }
-
-
-} 
+}

--- a/src/Jobs/Conversations/StartConversation.php
+++ b/src/Jobs/Conversations/StartConversation.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Socieboy\Forum\Jobs\Conversations;
 
 use App\Jobs\Job;
@@ -12,17 +11,17 @@ use Socieboy\Forum\Entities\Conversations\ConversationRepo;
 class StartConversation extends Job implements SelfHandling
 {
     /**
-     * @var
+     * @var string
      */
     protected $topic_id;
 
     /**
-     * @var
+     * @var string
      */
     protected $title;
 
     /**
-     * @var
+     * @var string
      */
     protected $message;
 
@@ -33,21 +32,17 @@ class StartConversation extends Job implements SelfHandling
 
     /**
      * Create a new job instance.
-     * @param $topic_id
-     * @param $title
-     * @param $message
+     * @param string $topic_id
+     * @param string $title
+     * @param string $message
      */
     function __construct($topic_id, $title, $message)
     {
         $this->topic_id = $topic_id;
-
         $this->title = $title;
-
         $this->message = strip_tags($message);
-
         $this->converter = new CommonMarkConverter();
     }
-
 
     /**
      * Execute the job.
@@ -58,11 +53,8 @@ class StartConversation extends Job implements SelfHandling
     public function handle(ConversationRepo $conversationRepo)
     {
         $conversation = $conversationRepo->model();
-
         $conversation->fill( $this->prepareDate() );
-
         $conversation->save();
-
     }
 
     /**
@@ -80,6 +72,4 @@ class StartConversation extends Job implements SelfHandling
             'slug' => Slug::generateUniqueSlug($this->title, 'conversations')
         ];
     }
-
-
 }

--- a/src/Jobs/Conversations/StartConversation.php
+++ b/src/Jobs/Conversations/StartConversation.php
@@ -4,6 +4,7 @@ namespace Socieboy\Forum\Jobs\Conversations;
 use App\Jobs\Job;
 use Illuminate\Contracts\Bus\SelfHandling;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Config;
 use League\CommonMark\CommonMarkConverter;
 use EasySlug\EasySlug\EasySlugFacade as Slug;
 use Socieboy\Forum\Entities\Conversations\ConversationRepo;
@@ -64,12 +65,14 @@ class StartConversation extends Job implements SelfHandling
      */
     public function prepareDate()
     {
+        $databasePrefix = (Config::get('forum.database.prefix') ? Config::get('forum.database.prefix') . '_' : '');
+
         return [
             'user_id' => Auth::User()->id,
             'title' => $this->title,
             'topic_id' => $this->topic_id,
             'message' => $this->converter->convertToHtml($this->message),
-            'slug' => Slug::generateUniqueSlug($this->title, 'conversations')
+            'slug' => Slug::generateUniqueSlug($this->title, $databasePrefix . 'conversations')
         ];
     }
 }

--- a/src/Jobs/LikeReply.php
+++ b/src/Jobs/LikeReply.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Socieboy\Forum\Jobs;
 
 use App\Jobs\Job;
@@ -13,14 +12,14 @@ class LikeReply extends Job implements SelfHandling
     use SerializesModels;
 
     /**
-     * @var
+     * @var int
      */
     protected $reply_id;
 
     /**
      * Create a new job instance.
      *
-     * @param $reply_id
+     * @param int $reply_id
      */
     public function __construct($reply_id)
     {
@@ -36,11 +35,8 @@ class LikeReply extends Job implements SelfHandling
     public function handle(LikeRepo $likeRepo)
     {
         $like = $likeRepo->model();
-
         $like->fill($this->prepareData());
-
         $like->save();
-
     }
 
     /**

--- a/src/Jobs/UnLikeReply.php
+++ b/src/Jobs/UnLikeReply.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Socieboy\Forum\Jobs;
 
 use App\Jobs\Job;
@@ -9,16 +8,15 @@ use Socieboy\Forum\Entities\Likes\LikeRepo;
 
 class UnLikeReply extends Job implements SelfHandling
 {
-
     /**
-     * @var
+     * @var int
      */
     protected $reply_id;
 
     /**
      * Create a new job instance.
      *
-     * @param $reply_id
+     * @param int $reply_id
      */
     public function __construct($reply_id)
     {
@@ -39,6 +37,5 @@ class UnLikeReply extends Job implements SelfHandling
             ->first();
 
         $like->delete();
-
     }
 }

--- a/src/Providers/ForumServiceProvider.php
+++ b/src/Providers/ForumServiceProvider.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Socieboy\Forum\Providers;
 
 use Illuminate\Support\ServiceProvider;
@@ -8,54 +7,50 @@ use Illuminate\Support\Facades\App;
 
 class ForumServiceProvider extends ServiceProvider
 {
-
-	/**
-	 * Bootstrap the application services.
-	 *
-	 * @return void
-	 */
-	public function boot()
-	{
+    /**
+     * Bootstrap the application services.
+     *
+     * @return void
+     */
+    public function boot()
+    {
         $this->publishFiles();
-
         $this->shareGlobalVariables();
-
-        $this->loadViewsFrom(__DIR__.'/../Views', 'Forum');
-
-        $this->loadTranslationsFrom(__DIR__.'/../Lang', 'Forum');
+        $this->loadViewsFrom(__DIR__ . '/../Views', 'Forum');
+        $this->loadTranslationsFrom(__DIR__ . '/../Lang', 'Forum');
     }
 
-	/**
-	 * Register the application services.
-	 *
-	 * @return void
-	 */
-	public function register()
-	{
+    /**
+     * Register the application services.
+     *
+     * @return void
+     */
+    public function register()
+    {
         App::register(\EasySlug\EasySlug\EasySlugServiceProvider::class);
 
-        $this->app->bindShared('command.forum.table', function ($app) {
-            return new MigrateForumCommand();
-        });
+        $this->app->bindShared(
+            'command.forum.table',
+            function ($app) {
+                return new MigrateForumCommand();
+            }
+        );
 
         $this->commands('command.forum.table');
-
         include __DIR__ . '/../routes.php';
-
-	}
+    }
 
     /**
      * Publish config files for the forum.
      */
     protected function publishFiles()
     {
-        $this->publishes([
-
-            __DIR__.'/../Config/forum.php' => base_path('config/forum.php'),
-
-            __DIR__.'/../Style/forum' => base_path('resources/assets/less/forum'),
-
-        ]);
+        $this->publishes(
+            [
+                __DIR__ . '/../Config/forum.php' => base_path('config/forum.php'),
+                __DIR__ . '/../Style/forum' => base_path('resources/assets/less/forum'),
+            ]
+        );
     }
 
     /**
@@ -64,9 +59,6 @@ class ForumServiceProvider extends ServiceProvider
     protected function shareGlobalVariables()
     {
         view()->share('template', config('forum.template'));
-
         view()->share('content', config('forum.content'));
-
     }
-
 }

--- a/src/Requests/ConversationRequest.php
+++ b/src/Requests/ConversationRequest.php
@@ -1,34 +1,31 @@
 <?php
-
 namespace Socieboy\Forum\Requests;
 
 use App\Http\Requests\Request;
 
 class ConversationRequest extends Request
 {
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
 
-	/**
-	 * Determine if the user is authorized to make this request.
-	 *
-	 * @return bool
-	 */
-	public function authorize()
-	{
-		return true;
-	}
-
-	/**
-	 * Get the validation rules that apply to the request.
-	 *
-	 * @return array
-	 */
-	public function rules()
-	{
-		return [
-			'title'     => 'required',
-            'message'   => 'required',
-            'topic_id'  => 'required'
-		];
-	}
-
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'title' => 'required',
+            'message' => 'required',
+            'topic_id' => 'required'
+        ];
+    }
 }

--- a/src/Requests/CorrectAnswerRequest.php
+++ b/src/Requests/CorrectAnswerRequest.php
@@ -1,5 +1,4 @@
 <?php
-
 namespace Socieboy\Forum\Requests;
 
 use App\Http\Requests\Request;
@@ -7,28 +6,26 @@ use Illuminate\Contracts\Auth\Guard;
 
 class CorrectAnswerRequest extends Request
 {
-
-	/**
-	 * Determine if the user is authorized to make this request.
-	 *
+    /**
+     * Determine if the user is authorized to make this request.
+     *
      * @param Guard $auth
-	 * @return bool
-	 */
-	public function authorize(Guard $auth)
-	{
-        	return $this->route('conversation_user_id') == $auth->user()->id;
-	}
+     * @return bool
+     */
+    public function authorize(Guard $auth)
+    {
+        return $this->route('conversation_user_id') == $auth->user()->id;
+    }
 
-	/**
-	 * Get the validation rules that apply to the request.
-	 *
-	 * @return array
-	 */
-	public function rules()
-	{
-		return [
-			'reply_id' => 'required'
-		];
-	}
-
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'reply_id' => 'required'
+        ];
+    }
 }

--- a/src/Requests/CreateReplyRequest.php
+++ b/src/Requests/CreateReplyRequest.php
@@ -1,33 +1,30 @@
 <?php
-
 namespace Socieboy\Forum\Requests;
 
 use App\Http\Requests\Request;
 
 class CreateReplyRequest extends Request
 {
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
 
-	/**
-	 * Determine if the user is authorized to make this request.
-	 *
-	 * @return bool
-	 */
-	public function authorize()
-	{
-		return true;
-	}
-
-	/**
-	 * Get the validation rules that apply to the request.
-	 *
-	 * @return array
-	 */
-	public function rules()
-	{
-		return [
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
             'conversation_id' => 'required|exists:conversations,id',
-			'message' => 'required'
-		];
-	}
-
+            'message' => 'required'
+        ];
+    }
 }

--- a/src/Requests/CreateReplyRequest.php
+++ b/src/Requests/CreateReplyRequest.php
@@ -2,6 +2,7 @@
 namespace Socieboy\Forum\Requests;
 
 use App\Http\Requests\Request;
+use Illuminate\Support\Facades\Config;
 
 class CreateReplyRequest extends Request
 {
@@ -22,8 +23,10 @@ class CreateReplyRequest extends Request
      */
     public function rules()
     {
+        $databasePrefix = (Config::get('forum.database.prefix') ? Config::get('forum.database.prefix') . '_' : '');
+
         return [
-            'conversation_id' => 'required|exists:conversations,id',
+            'conversation_id' => 'required|exists:'.$databasePrefix.'conversations,id',
             'message' => 'required'
         ];
     }

--- a/src/Requests/LikeRequest.php
+++ b/src/Requests/LikeRequest.php
@@ -1,32 +1,29 @@
 <?php
-
 namespace Socieboy\Forum\Requests;
 
 use App\Http\Requests\Request;
 
 class LikeRequest extends Request
 {
+    /**
+     * Determine if the user is authorized to make this request.
+     *
+     * @return bool
+     */
+    public function authorize()
+    {
+        return true;
+    }
 
-	/**
-	 * Determine if the user is authorized to make this request.
-	 *
-	 * @return bool
-	 */
-	public function authorize()
-	{
-		return true;
-	}
-
-	/**
-	 * Get the validation rules that apply to the request.
-	 *
-	 * @return array
-	 */
-	public function rules()
-	{
-		return [
-			'reply_id' => 'required'
+    /**
+     * Get the validation rules that apply to the request.
+     *
+     * @return array
+     */
+    public function rules()
+    {
+        return [
+            'reply_id' => 'required'
         ];
-	}
-
+    }
 }

--- a/src/Stubs/conversations.stub
+++ b/src/Stubs/conversations.stub
@@ -2,48 +2,49 @@
 
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\Config;
 
-class CreateConversationsTable extends Migration {
+class CreateConversationsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        $databasePrefix = (Config::get('forum.database.prefix') ? Config::get('forum.database.prefix') . '_' : '');
 
-	/**
-	 * Run the migrations.
-	 *
-	 * @return void
-	 */
-	public function up()
-	{
-	    // Create conversations table.
+        // Create conversations table.
+        Schema::create(
+            $databasePrefix . 'conversations',
+            function (Blueprint $table) {
+                $table->engine = 'InnoDB';
 
-        Schema::create('conversations', function (Blueprint $table) {
+                $table->increments('id');
+                $table->string('title');
+                $table->text('message');
+                $table->text('topic_id');
+                $table->integer('user_id')->unsigned();
+                $table->foreign('user_id')
+                    ->references('id')->on('users')->onDelete('cascade');
 
-            $table->engine = 'InnoDB';
-            $table->increments('id');
+                $table->string('slug');
+                $table->timestamps();
+            }
+        );
+    }
 
-            $table->string('title');
-            $table->text('message');
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        $databasePrefix = (Config::get('forum.database.prefix') ? Config::get('forum.database.prefix') . '_' : '');
 
-            $table->text('topic_id');
-
-            $table->integer('user_id')->unsigned();
-            $table->foreign('user_id')
-                ->references('id')->on('users')->onDelete('cascade');
-
-            $table->string('slug');
-
-            $table->timestamps();
-        });
-	}
-
-	/**
-	 * Reverse the migrations.
-	 *
-	 * @return void
-	 */
-	public function down()
-	{
-	    // Delete conversations table.
-
-		Schema::drop('conversations');
-	}
-
+        // Delete conversations table.
+        Schema::drop($databasePrefix . 'conversations');
+    }
 }

--- a/src/Stubs/likes.stub
+++ b/src/Stubs/likes.stub
@@ -3,45 +3,48 @@
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
 
-class CreateLikesTable extends Migration {
+class CreateLikesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        $databasePrefix = (Config::get('forum.database.prefix') ? Config::get('forum.database.prefix') . '_' : '');
 
-	/**
-	 * Run the migrations.
-	 *
-	 * @return void
-	 */
-	public function up()
-	{
-		// Create replies table
+        // Create replies table
+        Schema::create(
+            $databasePrefix . 'likes',
+            function (Blueprint $table) use ($databasePrefix) {
+                $table->engine = 'InnoDB';
 
-        Schema::create('likes', function (Blueprint $table) {
+                $table->increments('id');
+                $table->integer('user_id')->unsigned();
+                $table->foreign('user_id')
+                    ->references('id')->on('users')->onDelete('cascade');
 
-            $table->engine = 'InnoDB';
-            $table->increments('id');
+                $table->integer('reply_id')->unsigned();
+                $table->foreign('reply_id')
+                    ->references('id')->on($databasePrefix . 'replies')->onDelete('cascade');
 
-            $table->integer('user_id')->unsigned();
-            $table->foreign('user_id')
-                ->references('id')->on('users')->onDelete('cascade');
+                $table->timestamps();
+            }
+        );
+    }
 
-            $table->integer('reply_id')->unsigned();
-            $table->foreign('reply_id')
-                ->references('id')->on('replies')->onDelete('cascade');
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        $databasePrefix = (Config::get('forum.database.prefix') ? Config::get('forum.database.prefix') . '_' : '');
 
-            $table->timestamps();
-
-        });
-	}
-
-	/**
-	 * Reverse the migrations.
-	 *
-	 * @return void
-	 */
-	public function down()
-	{
         // Delete table replies
-        
-        Schema::drop('likes');
-	}
+        Schema::drop($databasePrefix . 'likes');
+    }
 
 }

--- a/src/Stubs/replies.stub
+++ b/src/Stubs/replies.stub
@@ -2,50 +2,52 @@
 
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\Config;
 
-class CreateRepliesTable extends Migration {
+class CreateRepliesTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        $databasePrefix = (Config::get('forum.database.prefix') ? Config::get('forum.database.prefix') . '_' : '');
 
-	/**
-	 * Run the migrations.
-	 *
-	 * @return void
-	 */
-	public function up()
-	{
-		// Create replies table
+        // Create replies table
+        Schema::create(
+            $databasePrefix . 'replies',
+            function (Blueprint $table) use ($databasePrefix) {
+                $table->engine = 'InnoDB';
 
-        Schema::create('replies', function (Blueprint $table) {
+                $table->increments('id');
+                $table->text('message');
+                $table->integer('conversation_id')->unsigned();
+                $table->foreign('conversation_id')
+                    ->references('id')->on($databasePrefix . 'conversations')->onDelete('cascade');
 
-            $table->engine = 'InnoDB';
-            $table->increments('id');
+                $table->integer('user_id')->unsigned();
+                $table->foreign('user_id')
+                    ->references('id')->on('users')->onDelete('cascade');
 
-            $table->text('message');
+                $table->boolean('correct_answer')->default(false);
+                $table->timestamps();
+            }
+        );
+    }
 
-            $table->integer('conversation_id')->unsigned();
-            $table->foreign('conversation_id')
-                ->references('id')->on('conversations')->onDelete('cascade');
-            
-            $table->integer('user_id')->unsigned();
-            $table->foreign('user_id')
-                ->references('id')->on('users')->onDelete('cascade');
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        $databasePrefix = (Config::get('forum.database.prefix') ? Config::get('forum.database.prefix') . '_' : '');
 
-            $table->boolean('correct_answer')->default(false);
-            
-            $table->timestamps();
-            
-        });
-	}
-
-	/**
-	 * Reverse the migrations.
-	 *
-	 * @return void
-	 */
-	public function down()
-	{
         // Delete table replies
-        
-        Schema::drop('replies');
-	}
+        Schema::drop($databasePrefix . 'replies');
+    }
 
 }

--- a/src/routes.php
+++ b/src/routes.php
@@ -1,86 +1,116 @@
 <?php
 
-Route::group(['prefix' => 'forum', 'namespace' => 'Socieboy\Forum\Controllers'], function ()
-{
+Route::group(
+    ['prefix' => 'forum', 'namespace' => 'Socieboy\Forum\Controllers'],
+    function () {
+        /**
+         * Route GET for the main page
+         */
+        get(
+            '/',
+            [
+                'as' => 'forum',
+                'uses' => 'ForumController@index'
+            ]
+        );
 
-    /**
-    *   Route GET for the main page
-    */
-        get('/', [
-          'as' => 'forum',
-          'uses' => 'ForumController@index'
-        ]);
+        /**
+         * Route GET to filter conversations by topic
+         */
+        get(
+            '/topic/{topic}',
+            [
+                'as' => 'forum.topic',
+                'uses' => 'ForumController@topic'
+            ]
+        );
 
-    /**
-     * Route GET to filter conversations by topic
-     */
-        get('/topic/{topic}', [
-          'as' => 'forum.topic',
-          'uses' => 'ForumController@topic'
-        ]);
+        /**
+         * Route POST to search or filter conversations
+         */
+        post(
+            '/search',
+            [
+                'as' => 'forum.search',
+                'uses' => 'ForumController@search'
+            ]
+        );
 
-    /**
-     * Route POST to search or filter conversations
-     */
-        post('/search', [
-            'as' => 'forum.search',
-            'uses' => 'ForumController@search'
-        ]);
+        /**
+         * Route POST to store a new conversation
+         */
+        post(
+            '/conversation',
+            [
+                'as' => 'forum.conversation.store',
+                'uses' => 'ConversationController@store'
+            ]
+        );
 
-    /**
-     *  Route POST to store a new conversation
-     */
+        /**
+         * Route GET to show a conversation
+         */
+        get(
+            '/conversation/{slug}',
+            [
+                'as' => 'forum.conversation.show',
+                'uses' => 'ConversationController@show'
+            ]
+        );
 
-        post('/conversation', [
-          'as' => 'forum.conversation.store',
-          'uses' => 'ConversationController@store'
-        ]);
+        /**
+         * Route POST to store a new reply
+         */
+        post(
+            '/conversation/{slug}/reply',
+            [
+                'as' => 'forum.conversation.reply.store',
+                'uses' => 'RepliesController@store'
+            ]
+        );
 
-    /**
-     * Route GET to show a conversation
-     */
-        get('/conversation/{slug}', [
-          'as' => 'forum.conversation.show',
-          'uses' => 'ConversationController@show'
-        ]);
+        /**
+         * Route POST to do like a reply
+         */
+        post(
+            '/conversation/{slug}/reply/like',
+            [
+                'as' => 'forum.conversation.reply.like',
+                'uses' => 'LikesController@like'
+            ]
+        );
 
-    /**
-     * Route POST to store a new reply
-     */
-        post('/conversation/{slug}/reply', [
-          'as' => 'forum.conversation.reply.store',
-          'uses' => 'RepliesController@store'
-        ]);
+        /**
+         * Route POST to do unlike a reply
+         */
+        post(
+            '/conversation/{slug}/reply/unlike',
+            [
+                'as' => 'forum.conversation.reply.unlike',
+                'uses' => 'LikesController@unlike'
+            ]
+        );
 
-    /**
-     * Route POST to do like a reply
-     */
-        post('/conversation/{slug}/reply/like', [
-          'as' => 'forum.conversation.reply.like',
-          'uses' => 'LikesController@like'
-        ]);
+        /**
+         * Route POST to check correct answer
+         */
+        post(
+            '/conversation/{slug}/reply/{conversation_user_id}/correct-answer',
+            [
+                'as' => 'forum.conversation.reply.correct-answer',
+                'uses' => 'RepliesController@correctAnswer'
+            ]
+        );
 
-    /**
-     * Route POST to do unlike a reply
-     */
-        post('/conversation/{slug}/reply/unlike', [
-          'as' => 'forum.conversation.reply.unlike',
-          'uses' => 'LikesController@unlike'
-        ]);
-
-    /**
-     * Route POST to check correct answer
-     */
-        post('/conversation/{slug}/reply/{conversation_user_id}/correct-answer', [
-          'as' => 'forum.conversation.reply.correct-answer',
-          'uses' => 'RepliesController@correctAnswer'
-        ]);
-
-    /**
-     * Route to profile.
-     */
-        get('/{id}/profile', [
-          'as' => 'forum.user.profile',
-          'uses' => 'ProfileController@show'
-        ]);
-});
+        /**
+         * Route to profile.
+         */
+        get(
+            '/{id}/profile',
+            [
+                'as' => 'forum.user.profile',
+                'uses' => 'ProfileController@show'
+            ]
+        );
+    }
+);


### PR DESCRIPTION
First of all: I really appreciate you putting this package out here in the open source world. So big thumbs up.

Now, I've might have gone a little overboard with this PR. Basicly I wanted to add the ability to use a prefix for database table names. Instead of having **replies** floating around in your database, you will now have the ability to prefix it from the configuration file with fx. "forum", so it will be named **forum_replies**.

I started adding the functionality and sort of cleaned up some of the code. There was some inconsistency in terms of indentation etc, so I ended up cleaning all of the code. Some changes might be because of my OCD. Sorry.

I thought I would create this PR so you could give me a response. Changes of this size would maybe be better just to create my own package, but since I'm still using 99% of your work, yeah ..

#### Changes made:
- Syntastic sugar (PSR-2 and stuff)
- Added a ``BaseModel`` to add the database table prefix to the ``$table`` property. The entities will extend upon the ``BaseModel`` instead of the ``Model`` from Eloquent.
- Edited files where the table name where hardcoded to instead read from config (forum.database.prefix)