### PR TITLE
Import Illuminate Controller instead of App namespaced Controller

### DIFF
--- a/src/Controllers/ConversationController.php
+++ b/src/Controllers/ConversationController.php
@@ -1,7 +1,7 @@
 <?php
 namespace Socieboy\Forum\Controllers;
 
-use App\Http\Controllers\Controller;
+use Illuminate\Routing\Controller;
 use Socieboy\Forum\Entities\Conversations\ConversationRepo;
 use Socieboy\Forum\Jobs\Conversations\CreateConversationThread;
 use Socieboy\Forum\Jobs\StartConversationJob;

--- a/src/Controllers/ForumController.php
+++ b/src/Controllers/ForumController.php
@@ -1,7 +1,7 @@
 <?php
 namespace Socieboy\Forum\Controllers;
 
-use \App\Http\Controllers\Controller;
+use Illuminate\Routing\Controller;
 use Illuminate\Http\Request;
 use Socieboy\Forum\Entities\Conversations\ConversationRepo;
 

--- a/src/Controllers/LikesController.php
+++ b/src/Controllers/LikesController.php
@@ -3,7 +3,7 @@ namespace Socieboy\Forum\Controllers;
 
 use Socieboy\Forum\Entities\Likes\LikeManager;
 use Socieboy\Forum\Entities\Likes\LikeRepo;
-use App\Http\Controllers\Controller;
+use Illuminate\Routing\Controller;
 use Socieboy\Forum\Requests\LikeRequest;
 
 class LikesController extends Controller

--- a/src/Controllers/ProfileController.php
+++ b/src/Controllers/ProfileController.php
@@ -1,7 +1,7 @@
 <?php
 namespace Socieboy\Forum\Controllers;
 
-use App\Http\Controllers\Controller;
+use Illuminate\Routing\Controller;
 
 class ProfileController extends Controller
 {

--- a/src/Controllers/RepliesController.php
+++ b/src/Controllers/RepliesController.php
@@ -1,7 +1,7 @@
 <?php
 namespace Socieboy\Forum\Controllers;
 
-use App\Http\Controllers\Controller;
+use Illuminate\Routing\Controller;
 use Illuminate\Http\Request;
 use Socieboy\Forum\Entities\Replies\ReplyRepo;
 use Socieboy\Forum\Jobs\Replies\SubscribeUserToThread;


### PR DESCRIPTION
This is my first time making a pull request, so sorry if I’m not doing it right or on the right branch.

You’re importing `\App\Http\Controllers\Controller`, which won’t work if the user has their application namespace set to something else like I do. Importing the Illuminate base controller fixes this.